### PR TITLE
Store Wallets as a Set

### DIFF
--- a/bruteforce.py
+++ b/bruteforce.py
@@ -4,7 +4,7 @@ from requests import get
 from time import sleep
 
 with open('wallets.txt', 'r') as file:
-    wallets = file.read()
+    wallets = set(file.read().striplines())
 
 max_p = 115792089237316195423570985008687907852837564279074904382605163141518161494336
 


### PR DESCRIPTION
Searching for the bitcoin address in a string will have O(n) lookup time, but if stored as a set, then the lookup time will be O(1).